### PR TITLE
wrote dockerfile and wrappers for docker build + run

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,6 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^build\.sh$
+^run\.sh$
+^Dockerfile$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM pennsive/r-env:base
+
+# install anything not already in pennsive/r-env:base
+# rgl requires X11 ref https://stackoverflow.com/a/43956492/2624391
+RUN apt-get update && apt-get install -y xorg libx11-dev libglu1-mesa-dev libfreetype6-dev
+RUN r -e "install.packages(c('doParallel', 'foreach', 'gtools', 'ggExtra', 'neuroim'))"
+RUN r -e "devtools::install_github('avalcarcel9/rtapas', dependencies = FALSE)"
+WORKDIR /src
+COPY . .
+ENTRYPOINT []
+CMD bash

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build -t pennsive/rtapas:latest .
+

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Assumes you have an x server (like xQuartz) already installed
+# and that the "Allow connections from network clients" option is activated
+# ref https://medium.com/@mreichelt/how-to-show-x11-windows-within-docker-on-mac-50759f4b65cb
+xhost + 127.0.0.1 # add 127.0.0.1 to x server acl
+docker run -ti -e DISPLAY=host.docker.internal:0 pennsive/rtapas:latest


### PR DESCRIPTION
rtapas requires rgl which is a GUI so this Dockerfile installs an x server and assumes you have an x client (e.g. xQuartz) installed on your host.

So, pulling and simply running from [docker hub](https://hub.docker.com/r/pennsive/rtapas) is not enough, you also need to configure X11 (and add localhost to x server ACL with `xhost + 127.0.0.1`) and then set the DISPLAY env var `docker run -ti -e DISPLAY=host.docker.internal:0 pennsive/rtapas:latest`